### PR TITLE
Use correct shebang.

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # foxbox auto setup script
 #


### PR DESCRIPTION
Hey Fred!

Just a trivial change needed for those using zsh. Note that `/bin/bash` is required (but this dep should be included in virtually any distro.

I've tested this on Ubuntu 15.04.
